### PR TITLE
fix libmp3lame i386 compile errors

### DIFF
--- a/audioencoder.lame/addon.xml.in
+++ b/audioencoder.lame/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audioencoder.lame"
-  version="1.0.0"
+  version="1.1.0"
   name="Lame MP3 Audio Encoder"
   provider-name="spiff">
   <requires>

--- a/depends/common/lame/01-field-width-fix.patch
+++ b/depends/common/lame/01-field-width-fix.patch
@@ -1,0 +1,25 @@
+Description: Fix warning on 64 bit machines. Explicitely set variables as
+ unsigned ints.
+Origin: http://git.debian.org/?p=pkg-multimedia/lame.git;a=blob;f=debian/patches/07-field-width-fix.patch
+Forwarded: commit:1.282
+Applied-Upstream: commit:1.282
+
+--- a/frontend/parse.c
++++ b/frontend/parse.c
+@@ -372,11 +372,11 @@
+     const char *b = get_lame_os_bitness();
+     const char *v = get_lame_version();
+     const char *u = get_lame_url();
+-    const size_t lenb = strlen(b);
+-    const size_t lenv = strlen(v);
+-    const size_t lenu = strlen(u);
+-    const size_t lw = 80;       /* line width of terminal in characters */
+-    const size_t sw = 16;       /* static width of text */
++    const unsigned int lenb = strlen(b);
++    const unsigned int lenv = strlen(v);
++    const unsigned int lenu = strlen(u);
++    const unsigned int lw = 80;       /* line width of terminal in characters */
++    const unsigned int sw = 16;       /* static width of text */
+ 
+     if (lw >= lenb + lenv + lenu + sw || lw < lenu + 2)
+         /* text fits in 80 chars per line, or line even too small for url */

--- a/depends/common/lame/02-unbreak-ftbfs-gcc4.4.patch
+++ b/depends/common/lame/02-unbreak-ftbfs-gcc4.4.patch
@@ -1,0 +1,93 @@
+Description: Unbreak compilation with gcc 4.4
+ This patch is only necessary before gcc 4.5, such as gcc 4.4 in debian/squeeze.
+ Actually, this is a workaround in config.h for a workaround in the autoconf
+ generated configure script, which comments out every #undef CPP statement.
+ This is actually documented in the autoconf manual, like here:
+ http://www.gnu.org/s/hello/manual/autoconf/Header-Templates.html
+Author: Reinhard Tartler <siretart@tauware.de>
+
+
+
+--- a/config.h.in
++++ b/config.h.in
+@@ -56,12 +56,14 @@
+ /* add ieee754_float32_t type */
+ #undef HAVE_IEEE754_FLOAT32_T
+ #ifndef HAVE_IEEE754_FLOAT32_T
++#define HAVE_IEEE754_FLOAT32_T
+ 	typedef float ieee754_float32_t;
+ #endif
+ 
+ /* add ieee754_float64_t type */
+ #undef HAVE_IEEE754_FLOAT64_T
+ #ifndef HAVE_IEEE754_FLOAT64_T
++#define HAVE_IEEE754_FLOAT64_T
+ 	typedef double ieee754_float64_t;
+ #endif
+ 
+@@ -71,6 +73,7 @@
+ /* add ieee854_float80_t type */
+ #undef HAVE_IEEE854_FLOAT80_T
+ #ifndef HAVE_IEEE854_FLOAT80_T
++#define HAVE_IEEE854_FLOAT80_T
+ 	typedef long double ieee854_float80_t;
+ #endif
+ 
+--- a/configure.in
++++ b/configure.in
+@@ -147,6 +147,7 @@
+ [/* add uint8_t type */
+ #undef HAVE_UINT8_T
+ #ifndef HAVE_UINT8_T
++#define HAVE_UINT8_T
+ 	typedef unsigned char uint8_t;
+ #endif])
+ 
+@@ -154,6 +155,7 @@
+ [/* add int8_t type */
+ #undef HAVE_INT8_T
+ #ifndef HAVE_INT8_T
++#define HAVE_INT8_T
+ 	typedef char int8_t;
+ #endif])
+ 
+@@ -161,6 +163,7 @@
+ [/* add uint16_t type */
+ #undef HAVE_UINT16_T
+ #ifndef HAVE_UINT16_T
++#define HAVE_UINT16_T
+ 	typedef unsigned short uint16_t;
+ #endif])
+ 
+@@ -168,6 +171,7 @@
+ [/* add int16_t type */
+ #undef HAVE_INT16_T
+ #ifndef HAVE_INT16_T
++#define HAVE_INT16_T
+ 	typedef short int16_t;
+ #endif])
+ 
+@@ -275,6 +279,7 @@
+ [/* add ieee854_float80_t type */
+ #undef HAVE_IEEE854_FLOAT80_T
+ #ifndef HAVE_IEEE854_FLOAT80_T
++#define HAVE_IEEE854_FLOAT80_T
+ 	typedef long double ieee854_float80_t;
+ #endif])
+ 
+@@ -287,6 +292,7 @@
+ [/* add ieee754_float64_t type */
+ #undef HAVE_IEEE754_FLOAT64_T
+ #ifndef HAVE_IEEE754_FLOAT64_T
++#define HAVE_IEEE754_FLOAT64_T
+ 	typedef double ieee754_float64_t;
+ #endif])
+ 
+@@ -294,6 +300,7 @@
+ [/* add ieee754_float32_t type */
+ #undef HAVE_IEEE754_FLOAT32_T
+ #ifndef HAVE_IEEE754_FLOAT32_T
++#define HAVE_IEEE754_FLOAT32_T
+ 	typedef float ieee754_float32_t;
+ #endif])
+ 

--- a/depends/common/lame/03-privacy-breach.patch
+++ b/depends/common/lame/03-privacy-breach.patch
@@ -1,0 +1,267 @@
+Description: Fix privacy-breach lintian error
+Author: Sebastian Ramacher <sramacher@debian.org>
+Last-Update: 2014-08-30
+
+--- lame-3.99.5+repack1.orig/doc/html/about.html
++++ lame-3.99.5+repack1/doc/html/about.html
+@@ -116,9 +116,9 @@ MPEG2 sample rates are 16Khz, 22.05Khz a
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+--- lame-3.99.5+repack1.orig/doc/html/abr.html
++++ lame-3.99.5+repack1/doc/html/abr.html
+@@ -90,9 +90,9 @@ than that of CBR for the target bitrate.
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+@@ -109,4 +109,4 @@ href="http://www.brightercreative.co.uk"
+ </div>
+ 
+ </body>
+-</html>
+\ No newline at end of file
++</html>
+--- lame-3.99.5+repack1.orig/doc/html/cbr.html
++++ lame-3.99.5+repack1/doc/html/cbr.html
+@@ -82,9 +82,9 @@ without scanning and partially decoding
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+@@ -101,4 +101,4 @@ href="http://www.brightercreative.co.uk"
+ </div>
+ 
+ </body>
+-</html>
+\ No newline at end of file
++</html>
+--- lame-3.99.5+repack1.orig/doc/html/contact.html
++++ lame-3.99.5+repack1/doc/html/contact.html
+@@ -104,9 +104,9 @@
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+@@ -123,4 +123,4 @@ href="http://www.brightercreative.co.uk"
+ </div>
+ 
+ </body>
+-</html>
+\ No newline at end of file
++</html>
+--- lame-3.99.5+repack1.orig/doc/html/contributors.html
++++ lame-3.99.5+repack1/doc/html/contributors.html
+@@ -169,9 +169,9 @@
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+@@ -188,4 +188,4 @@ href="http://www.brightercreative.co.uk"
+ </div>
+ 
+ </body>
+-</html>
+\ No newline at end of file
++</html>
+--- lame-3.99.5+repack1.orig/doc/html/detailed.html
++++ lame-3.99.5+repack1/doc/html/detailed.html
+@@ -1259,9 +1259,9 @@ so using it shouldn't cause harm.
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+--- lame-3.99.5+repack1.orig/doc/html/history.html
++++ lame-3.99.5+repack1/doc/html/history.html
+@@ -3450,8 +3450,7 @@ the exe. Thanks to <b>Lars Magne Ingebri
+ <center>
+ <p>
+   <a href="http://validator.w3.org/check?uri=referer">
+-    <img src="http://www.w3.org/Icons/valid-html401"
+-	 alt="Valid HTML 4.01 Transitional" height="31" width="88">
++	  Valid HTML 4.01 Transitional
+   </a>
+ </p>
+ </center>
+--- lame-3.99.5+repack1.orig/doc/html/index.html
++++ lame-3.99.5+repack1/doc/html/index.html
+@@ -51,9 +51,9 @@
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+--- lame-3.99.5+repack1.orig/doc/html/introduction.html
++++ lame-3.99.5+repack1/doc/html/introduction.html
+@@ -163,9 +163,9 @@ transparency all of the time. This is th
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+--- lame-3.99.5+repack1.orig/doc/html/links.html
++++ lame-3.99.5+repack1/doc/html/links.html
+@@ -914,9 +914,9 @@ tests:</i></a></h3>
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+@@ -933,4 +933,4 @@ href="http://www.brightercreative.co.uk"
+ </div>
+ 
+ </body>
+-</html>
+\ No newline at end of file
++</html>
+--- lame-3.99.5+repack1.orig/doc/html/list.html
++++ lame-3.99.5+repack1/doc/html/list.html
+@@ -47,9 +47,9 @@
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+@@ -66,4 +66,4 @@ href="http://www.brightercreative.co.uk"
+ </div>
+ 
+ </body>
+-</html>
+\ No newline at end of file
++</html>
+--- lame-3.99.5+repack1.orig/doc/html/ms_stereo.html
++++ lame-3.99.5+repack1/doc/html/ms_stereo.html
+@@ -104,9 +104,9 @@ href="http://en.wikipedia.org/wiki/Joint
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+@@ -123,4 +123,4 @@ href="http://www.brightercreative.co.uk"
+ </div>
+ 
+ </body>
+-</html>
+\ No newline at end of file
++</html>
+--- lame-3.99.5+repack1.orig/doc/html/usage.html
++++ lame-3.99.5+repack1/doc/html/usage.html
+@@ -116,9 +116,9 @@ sounds transparent. Use lossless codecs
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+--- lame-3.99.5+repack1.orig/doc/html/vbr.html
++++ lame-3.99.5+repack1/doc/html/vbr.html
+@@ -61,9 +61,9 @@ file size is quite unpredictable, and ca
+ </div>
+ <div id="footer">
+ 
+-<a href="http://sourceforge.net/projects/lame"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=290&amp;type=12"
+- alt="Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads"
+- border="0" height="30" width="120" /></a>
++<a href="http://sourceforge.net/projects/lame">
++ Get LAME (Lame Aint an MP3 Encoder) at SourceForge.net. Fast, secure and Free Open Source software downloads
++</a>
+ 
+ <a href="http://validator.w3.org/#validate_by_upload"><img src="images/valid-xhtml10.png"
+  alt="Valid XHTML 1.0 Transitional" border="0" height="31" width="88" /></a>
+@@ -80,4 +80,4 @@ href="http://www.brightercreative.co.uk"
+ </div>
+ 
+ </body>
+-</html>
+\ No newline at end of file
++</html>

--- a/depends/common/lame/04-msse.patch
+++ b/depends/common/lame/04-msse.patch
@@ -1,0 +1,17 @@
+Description: Build xmm_quantize_sub.c with -msse
+Author: Sebastian Ramacher <sramacher@debian.org>
+Bug: http://sourceforge.net/p/lame/bugs/443/
+Bug-Debian: https://bugs.debian.org/760047
+Forwarded: http://sourceforge.net/p/lame/bugs/443/
+Last-Update: 2014-08-31
+
+--- lame-3.99.5+repack1.orig/libmp3lame/vector/Makefile.am
++++ lame-3.99.5+repack1/libmp3lame/vector/Makefile.am
+@@ -20,6 +20,7 @@ xmm_sources = xmm_quantize_sub.c
+ 
+ if WITH_XMM
+ liblamevectorroutines_la_SOURCES = $(xmm_sources)
++liblamevectorroutines_la_CFLAGS = -msse
+ endif
+ 
+ noinst_HEADERS = lame_intrin.h

--- a/depends/common/lame/05-ansi2knr2devnull.patch
+++ b/depends/common/lame/05-ansi2knr2devnull.patch
@@ -1,0 +1,43 @@
+Description: Patch out remaining ansi2knr.
+Author: Dimitri John Ledkov <xnox@ubuntu.com>
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=755111
+--- a/configure.in
++++ b/configure.in
+@@ -78,7 +78,6 @@
+ fi
+ 
+ dnl more automake stuff
+-AM_C_PROTOTYPES
+ 
+ AC_CHECK_HEADER(dmalloc.h)
+ if test "${ac_cv_header_dmalloc_h}" = "yes"; then
+--- a/doc/man/Makefile.am
++++ b/doc/man/Makefile.am
+@@ -1,6 +1,6 @@
+ ## $Id: Makefile.am,v 1.1 2000/10/22 11:39:44 aleidinger Exp $
+ 
+-AUTOMAKE_OPTIONS = foreign ansi2knr
++AUTOMAKE_OPTIONS = foreign
+ 
+ man_MANS = lame.1
+ EXTRA_DIST = ${man_MANS}
+--- a/libmp3lame/i386/Makefile.am
++++ b/libmp3lame/i386/Makefile.am
+@@ -1,6 +1,6 @@
+ ## $Id: Makefile.am,v 1.26 2011/04/04 09:42:34 aleidinger Exp $
+ 
+-AUTOMAKE_OPTIONS = foreign $(top_srcdir)/ansi2knr
++AUTOMAKE_OPTIONS = foreign
+ 
+ DEFS = @DEFS@ @CONFIG_DEFS@
+ 
+--- a/doc/html/Makefile.am
++++ b/doc/html/Makefile.am
+@@ -1,6 +1,6 @@
+ ## $Id: Makefile.am,v 1.7 2010/09/30 20:58:40 jaz001 Exp $
+ 
+-AUTOMAKE_OPTIONS = foreign ansi2knr
++AUTOMAKE_OPTIONS = foreign
+ 
+ docdir = $(datadir)/doc
+ pkgdocdir = $(docdir)/$(PACKAGE)

--- a/depends/common/lame/06-gtk1-ac-directives.patch
+++ b/depends/common/lame/06-gtk1-ac-directives.patch
@@ -1,0 +1,205 @@
+Description: Include GTK-1 autoconf directives in build system.
+Origin: http://anonscm.debian.org/gitweb/?p=pkg-multimedia/lame.git;a=tree;f=debian/patches
+Forwarded: yes
+Applied-Upstream: http://lame.cvs.sf.net/viewvc/lame/lame/acinclude.m4?revision=1.6
+
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -85,4 +85,197 @@
+ [AC_MSG_WARN(can't check for IEEE854 compliant 80 bit floats)]
+ )])]) # alex_IEEE854_FLOAT80
+ 
++# Configure paths for GTK+
++# Owen Taylor     97-11-3
+ 
++dnl AM_PATH_GTK([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND [, MODULES]]]])
++dnl Test for GTK, and define GTK_CFLAGS and GTK_LIBS
++dnl
++AC_DEFUN([AM_PATH_GTK],
++[dnl
++dnl Get the cflags and libraries from the gtk-config script
++dnl
++AC_ARG_WITH(gtk-prefix,[  --with-gtk-prefix=PFX   Prefix where GTK is installed (optional)],
++            gtk_config_prefix="$withval", gtk_config_prefix="")
++AC_ARG_WITH(gtk-exec-prefix,[  --with-gtk-exec-prefix=PFX Exec prefix where GTK is installed (optional)],
++            gtk_config_exec_prefix="$withval", gtk_config_exec_prefix="")
++AC_ARG_ENABLE(gtktest, [  --disable-gtktest       Do not try to compile and run a test GTK program],
++        , enable_gtktest=yes)
++
++  for module in . $4
++  do
++      case "$module" in
++         gthread)
++             gtk_config_args="$gtk_config_args gthread"
++         ;;
++      esac
++  done
++
++  if test x$gtk_config_exec_prefix != x ; then
++     gtk_config_args="$gtk_config_args --exec-prefix=$gtk_config_exec_prefix"
++     if test x${GTK_CONFIG+set} != xset ; then
++        GTK_CONFIG=$gtk_config_exec_prefix/bin/gtk-config
++     fi
++  fi
++  if test x$gtk_config_prefix != x ; then
++     gtk_config_args="$gtk_config_args --prefix=$gtk_config_prefix"
++     if test x${GTK_CONFIG+set} != xset ; then
++        GTK_CONFIG=$gtk_config_prefix/bin/gtk-config
++     fi
++  fi
++
++  AC_PATH_PROG(GTK_CONFIG, gtk-config, no)
++  min_gtk_version=ifelse([$1], ,0.99.7,$1)
++  AC_MSG_CHECKING(for GTK - version >= $min_gtk_version)
++  no_gtk=""
++  if test "$GTK_CONFIG" = "no" ; then
++    no_gtk=yes
++  else
++    GTK_CFLAGS=`$GTK_CONFIG $gtk_config_args --cflags`
++    GTK_LIBS=`$GTK_CONFIG $gtk_config_args --libs`
++    gtk_config_major_version=`$GTK_CONFIG $gtk_config_args --version | \
++           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
++    gtk_config_minor_version=`$GTK_CONFIG $gtk_config_args --version | \
++           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
++    gtk_config_micro_version=`$GTK_CONFIG $gtk_config_args --version | \
++           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
++    if test "x$enable_gtktest" = "xyes" ; then
++      ac_save_CFLAGS="$CFLAGS"
++      ac_save_LIBS="$LIBS"
++      CFLAGS="$CFLAGS $GTK_CFLAGS"
++      LIBS="$GTK_LIBS $LIBS"
++dnl
++dnl Now check if the installed GTK is sufficiently new. (Also sanity
++dnl checks the results of gtk-config to some extent
++dnl
++      rm -f conf.gtktest
++      AC_TRY_RUN([
++#include <gtk/gtk.h>
++#include <stdio.h>
++#include <stdlib.h>
++
++int
++main ()
++{
++  int major, minor, micro;
++  char *tmp_version;
++
++  system ("touch conf.gtktest");
++
++  /* HP/UX 9 (%@#!) writes to sscanf strings */
++  tmp_version = g_strdup("$min_gtk_version");
++  if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
++     printf("%s, bad version string\n", "$min_gtk_version");
++     exit(1);
++   }
++
++  if ((gtk_major_version != $gtk_config_major_version) ||
++      (gtk_minor_version != $gtk_config_minor_version) ||
++      (gtk_micro_version != $gtk_config_micro_version))
++    {
++      printf("\n*** 'gtk-config --version' returned %d.%d.%d, but GTK+ (%d.%d.%d)\n",
++             $gtk_config_major_version, $gtk_config_minor_version, $gtk_config_micro_version,
++             gtk_major_version, gtk_minor_version, gtk_micro_version);
++      printf ("*** was found! If gtk-config was correct, then it is best\n");
++      printf ("*** to remove the old version of GTK+. You may also be able to fix the error\n");
++      printf("*** by modifying your LD_LIBRARY_PATH enviroment variable, or by editing\n");
++      printf("*** /etc/ld.so.conf. Make sure you have run ldconfig if that is\n");
++      printf("*** required on your system.\n");
++      printf("*** If gtk-config was wrong, set the environment variable GTK_CONFIG\n");
++      printf("*** to point to the correct copy of gtk-config, and remove the file config.cache\n");
++      printf("*** before re-running configure\n");
++    }
++#if defined (GTK_MAJOR_VERSION) && defined (GTK_MINOR_VERSION) && defined (GTK_MICRO_VERSION)
++  else if ((gtk_major_version != GTK_MAJOR_VERSION) ||
++     (gtk_minor_version != GTK_MINOR_VERSION) ||
++           (gtk_micro_version != GTK_MICRO_VERSION))
++    {
++      printf("*** GTK+ header files (version %d.%d.%d) do not match\n",
++       GTK_MAJOR_VERSION, GTK_MINOR_VERSION, GTK_MICRO_VERSION);
++      printf("*** library (version %d.%d.%d)\n",
++       gtk_major_version, gtk_minor_version, gtk_micro_version);
++    }
++#endif /* defined (GTK_MAJOR_VERSION) ... */
++  else
++    {
++      if ((gtk_major_version > major) ||
++        ((gtk_major_version == major) && (gtk_minor_version > minor)) ||
++        ((gtk_major_version == major) && (gtk_minor_version == minor) && (gtk_micro_version >= micro)))
++      {
++        return 0;
++       }
++     else
++      {
++        printf("\n*** An old version of GTK+ (%d.%d.%d) was found.\n",
++               gtk_major_version, gtk_minor_version, gtk_micro_version);
++        printf("*** You need a version of GTK+ newer than %d.%d.%d. The latest version of\n",
++         major, minor, micro);
++        printf("*** GTK+ is always available from ftp://ftp.gtk.org.\n");
++        printf("***\n");
++        printf("*** If you have already installed a sufficiently new version, this error\n");
++        printf("*** probably means that the wrong copy of the gtk-config shell script is\n");
++        printf("*** being found. The easiest way to fix this is to remove the old version\n");
++        printf("*** of GTK+, but you can also set the GTK_CONFIG environment to point to the\n");
++        printf("*** correct copy of gtk-config. (In this case, you will have to\n");
++        printf("*** modify your LD_LIBRARY_PATH enviroment variable, or edit /etc/ld.so.conf\n");
++        printf("*** so that the correct libraries are found at run-time))\n");
++      }
++    }
++  return 1;
++}
++],, no_gtk=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
++       CFLAGS="$ac_save_CFLAGS"
++       LIBS="$ac_save_LIBS"
++     fi
++  fi
++  if test "x$no_gtk" = x ; then
++     AC_MSG_RESULT(yes)
++     ifelse([$2], , :, [$2])
++  else
++     AC_MSG_RESULT(no)
++     if test "$GTK_CONFIG" = "no" ; then
++       echo "*** The gtk-config script installed by GTK could not be found"
++       echo "*** If GTK was installed in PREFIX, make sure PREFIX/bin is in"
++       echo "*** your path, or set the GTK_CONFIG environment variable to the"
++       echo "*** full path to gtk-config."
++     else
++       if test -f conf.gtktest ; then
++        :
++       else
++          echo "*** Could not run GTK test program, checking why..."
++          CFLAGS="$CFLAGS $GTK_CFLAGS"
++          LIBS="$LIBS $GTK_LIBS"
++          AC_TRY_LINK([
++#include <gtk/gtk.h>
++#include <stdio.h>
++],      [ return ((gtk_major_version) || (gtk_minor_version) || (gtk_micro_version)); ],
++        [ echo "*** The test program compiled, but did not run. This usually means"
++          echo "*** that the run-time linker is not finding GTK or finding the wrong"
++          echo "*** version of GTK. If it is not finding GTK, you'll need to set your"
++          echo "*** LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf to point"
++          echo "*** to the installed location  Also, make sure you have run ldconfig if that"
++          echo "*** is required on your system"
++    echo "***"
++          echo "*** If you have an old version installed, it is best to remove it, although"
++          echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH"
++          echo "***"
++          echo "*** If you have a RedHat 5.0 system, you should remove the GTK package that"
++          echo "*** came with the system with the command"
++          echo "***"
++          echo "***    rpm --erase --nodeps gtk gtk-devel" ],
++        [ echo "*** The test program failed to compile or link. See the file config.log for the"
++          echo "*** exact error that occured. This usually means GTK was incorrectly installed"
++          echo "*** or that you have moved GTK since it was installed. In the latter case, you"
++          echo "*** may want to edit the gtk-config script: $GTK_CONFIG" ])
++          CFLAGS="$ac_save_CFLAGS"
++          LIBS="$ac_save_LIBS"
++       fi
++     fi
++     GTK_CFLAGS=""
++     GTK_LIBS=""
++     ifelse([$3], , :, [$3])
++  fi
++  AC_SUBST(GTK_CFLAGS)
++  AC_SUBST(GTK_LIBS)
++  rm -f conf.gtktest
++])

--- a/depends/common/lame/CMakeLists.txt
+++ b/depends/common/lame/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 2.8)
 include(ExternalProject)
 externalproject_add(lame
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}
+                    UPDATE_COMMAND autoreconf -vif
                     CONFIGURE_COMMAND <SOURCE_DIR>/configure 
                       --prefix=${OUTPUT_DIR}
                       --disable-gtktest


### PR DESCRIPTION
Found during creation of my multi platform system a fault with libmp3lame on linux i386 system which becomes called from ./tools/buildsteps/linux32/make-depends.

Also reported here on debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760047

This change is related to request https://github.com/xbmc/xbmc/pull/7974 where the libmp3lame becomes removed from depends and now must be done complete here.