### PR TITLE
[Matrix] fix travis ci debian build (wrong Kodi include dir) and reduce other build works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ env:
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: travis
       sudo: required
       compiler: clang
     - os: linux
-      dist: bionic
+      dist: travis
       sudo: required
       compiler: gcc
       env: DEBIAN_BUILD=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-addon-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,12 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
-      compiler: gcc
-    - os: linux
-      dist: xenial
-      sudo: required
       compiler: clang
     - os: linux
       dist: bionic
       sudo: required
       compiler: gcc
       env: DEBIAN_BUILD=true
-    - os: osx
-      osx_image: xcode10.2
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew link gettext --force; fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a [Kodi](https://kodi.tv) LAME audio encoder add-on.
 
 #### CI Testing
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audioencoder.lame.svg?branch=Matrix)](https://travis-ci.org/xbmc/audioencoder.lame/branches)
+[![Build Status](https://travis-ci.com/xbmc/audioencoder.lame.svg?branch=Matrix)](https://travis-ci.com/xbmc/audioencoder.lame/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audioencoder.lame?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=22&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audioencoder.lame/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudioencoder.lame/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)

--- a/audioencoder.lame/addon.xml.in
+++ b/audioencoder.lame/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audioencoder.lame"
-  version="3.0.1"
+  version="3.0.2"
   name="Lame MP3 Audio Encoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/depends/common/lame/lame.txt
+++ b/depends/common/lame/lame.txt
@@ -1,1 +1,1 @@
-lame http://ftp.kodi.tv/build-deps/sources/lame-3.100.tar.gz
+lame http://mirrors.kodi.tv/build-deps/sources/lame-3.100.tar.gz

--- a/depends/windows/lame/lame.txt
+++ b/depends/windows/lame/lame.txt
@@ -1,1 +1,1 @@
-lame http://ftp.kodi.tv/build-deps/sources/lame-3.100.tar.gz
+lame http://mirrors.kodi.tv/build-deps/sources/lame-3.100.tar.gz


### PR DESCRIPTION
As there becomes soon a switch to the travis-ci.com where have time limitations are the OSX build and Linux gcc build removed.

The Debian build stays and the Linux clang language build.
Them good to have as Jenkins not makes Debian build and the Linux build to check about another way to create addon.

Also a fix about https://github.com/xbmc/audioencoder.lame/issues/28 inside.