### PR TITLE
[Leia] reduce build works and also a fix about #28 inside.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: focal
       sudo: required
       compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,7 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
-      compiler: gcc
-    - os: linux
-      dist: xenial
-      sudo: required
       compiler: clang
-    - os: osx
-      osx_image: xcode9.4
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew link gettext --force; fi

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a [Kodi] (http://kodi.tv) LAME audio encoder add-on.
 
 #### CI Testing
-[![Build Status](https://travis-ci.org/xbmc/audioencoder.lame.svg?branch=master)](https://travis-ci.org/xbmc/audioencoder.lame)
+[![Build Status](https://travis-ci.com/xbmc/audioencoder.lame.svg?branch=master)](https://travis-ci.com/xbmc/audioencoder.lame)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audioencoder.lame?branchName=Leia)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=22&branchName=Leia)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
 

--- a/audioencoder.lame/addon.xml.in
+++ b/audioencoder.lame/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audioencoder.lame"
-  version="2.0.4"
+  version="2.0.5"
   name="Lame MP3 Audio Encoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/depends/common/lame/lame.txt
+++ b/depends/common/lame/lame.txt
@@ -1,1 +1,1 @@
-lame http://ftp.kodi.tv/build-deps/sources/lame-3.100.tar.gz
+lame http://mirrors.kodi.tv/build-deps/sources/lame-3.100.tar.gz

--- a/depends/windows/lame/lame.txt
+++ b/depends/windows/lame/lame.txt
@@ -1,1 +1,1 @@
-lame http://ftp.kodi.tv/build-deps/sources/lame-3.100.tar.gz
+lame http://mirrors.kodi.tv/build-deps/sources/lame-3.100.tar.gz


### PR DESCRIPTION
As there becomes soon a switch to the travis-ci.com where have time limitations are the OSX build and Linux gcc build removed.

The Linux clang language build stays.

Also a fix about #28 inside.