### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is a [Kodi](https://kodi.tv) LAME audio encoder add-on.
 
 #### CI Testing
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.com/xbmc/audioencoder.lame.svg?branch=Matrix)](https://travis-ci.com/xbmc/audioencoder.lame/branches)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audioencoder.lame?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=22&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audioencoder.lame/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudioencoder.lame/branches/)
+[![Build Status](https://travis-ci.com/xbmc/audioencoder.lame.svg?branch=Nexus)](https://travis-ci.com/xbmc/audioencoder.lame/branches)
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audioencoder.lame?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=22&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audioencoder.lame/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudioencoder.lame/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audioencoder.lame?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audioencoder-lame?branch=Matrix) -->
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audioencoder.lame?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/audioencoder-lame?branch=Nexus) -->
 
 ## Build instructions
 
@@ -19,7 +19,7 @@ Also make sure you follow this README from the branch in question.
 ### Linux
 
 1. `git clone --branch master https://github.com/xbmc/xbmc.git`
-2. `git clone --branch Matrix https://github.com/audioencoder.lame/audioencoder.lame.git`
+2. `git clone --branch Nexus https://github.com/audioencoder.lame/audioencoder.lame.git`
 3. `cd audioencoder.lame && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=audioencoder.lame -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/project/cmake/addons`
 5. `make`

--- a/audioencoder.lame/addon.xml.in
+++ b/audioencoder.lame/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audioencoder.lame"
-  version="3.0.2"
+  version="20.0.0"
   name="Lame MP3 Audio Encoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: audioencoder.lame
 
 Files: *
 Copyright: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
-           2013-2020 Team Kodi
+           2013-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ License: GPL-2+
 Files: debian/*
 Copyright: 2013 Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
            2013 wsnipex <wsnipex@a1.net>
-           2013-2020 Team Kodi
+           2013-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/EncoderLame.cpp
+++ b/src/EncoderLame.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.