### PR TITLE
don't build iconv for Apple platforms

### DIFF
--- a/depends/common/iconv/platforms.txt
+++ b/depends/common/iconv/platforms.txt
@@ -1,0 +1,1 @@
+!darwin_embedded !osx


### PR DESCRIPTION
- Apple has iconv in the system
- this fixes building inputstream.ffmpegdirect on iOS/tvOS - it no longer tries to use the strangely built libiconv.a (no required symbols there). Successful Kodi build with all addons: https://jenkins.kodi.tv/job/TVOS/17733/

related: https://github.com/xbmc/audiodecoder.sacd/pull/78